### PR TITLE
Fix: Lower Swift tools version to 6.0 for CI compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
## Summary
- Changed Swift tools version from 6.1 to 6.0
- Fixes CI build failures in projects using this package

## Why
The CI environment only has Swift 6.0.0 available, causing builds to fail with the error:
`package 'sdkgatekeeper' is using Swift tools version 6.1.0 but the installed version is 6.0.0`

This change ensures compatibility with current CI environments.

🤖 Generated with [Claude Code](https://claude.ai/code)